### PR TITLE
MF-15-Change to not use Property when calculating expiry

### DIFF
--- a/src/SFA.DAS.Reservations.Domain.UnitTests/Reservations/WhenGettingReservationForAccount.cs
+++ b/src/SFA.DAS.Reservations.Domain.UnitTests/Reservations/WhenGettingReservationForAccount.cs
@@ -101,14 +101,17 @@ namespace SFA.DAS.Reservations.Domain.UnitTests.Reservations
             Assert.AreEqual(_expectedCourse.Level.ToString(), actualRuleCourse.Level);
         }
 
-        [Test]
-        public void Then_When_Creating_A_New_Reservation_The_Expiry_Is_Set_To_The_Last_Day_Of_The_Month_With_Added_Expiry_Months()
+        [TestCase(2018,04,30)]
+        [TestCase(2018,02,28)]
+        [TestCase(2018,10,31)]
+        public void Then_When_Creating_A_New_Reservation_The_Expiry_Is_Set_To_The_Last_Day_Of_The_Month_With_Added_Expiry_Months(int year, int month, int day)
         {
             //Arrange
-            var expectedExpiryDate = new DateTime(2018, 03, 31);
+            var expectedExpiryDate = new DateTime(year, month, day);
+            var expiryPeriod = 1;
 
             //Act
-            _reservation = new Reservation(123, new DateTime(2018,02,03),1 );
+            _reservation = new Reservation(123, new DateTime(2018,month-expiryPeriod,03),expiryPeriod);
 
             //Assert
             Assert.AreEqual(expectedExpiryDate,_reservation.ExpiryDate);

--- a/src/SFA.DAS.Reservations.Domain/Reservations/Reservation.cs
+++ b/src/SFA.DAS.Reservations.Domain/Reservations/Reservation.cs
@@ -80,7 +80,7 @@ namespace SFA.DAS.Reservations.Domain.Reservations
         private DateTime GetExpiryDateFromStartDate(int expiryPeriodInMonths)
         {
             var expiryDate = StartDate.AddMonths(expiryPeriodInMonths);
-            var lastDayInMonth = DateTime.DaysInMonth(ExpiryDate.Year, ExpiryDate.Month);
+            var lastDayInMonth = DateTime.DaysInMonth(expiryDate.Year, expiryDate.Month);
             return new DateTime(expiryDate.Year, expiryDate.Month, lastDayInMonth);
         }
     }


### PR DESCRIPTION
Changed the creating of the expiry date to use the calculated var year
and month rather than the property that hadn't been initialised