### PR TITLE
Added health checks to API

### DIFF
--- a/src/SFA.DAS.Reservations.Api/SFA.DAS.Reservations.Api.csproj
+++ b/src/SFA.DAS.Reservations.Api/SFA.DAS.Reservations.Api.csproj
@@ -6,11 +6,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="2.2.0" />
     <PackageReference Include="MediatR" Version="6.0.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.8.0" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.1.5" />

--- a/src/SFA.DAS.Reservations.Api/Startup.cs
+++ b/src/SFA.DAS.Reservations.Api/Startup.cs
@@ -12,10 +12,10 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using SFA.DAS.Reservations.Api.StartupConfig;
 using SFA.DAS.Reservations.Application.AccountReservations.Commands;
 using SFA.DAS.Reservations.Application.AccountReservations.Queries;
 using SFA.DAS.Reservations.Application.AccountReservations.Services;
-using SFA.DAS.Reservations.Application.Courses.Queries.GetCourses;
 using SFA.DAS.Reservations.Application.Courses.Services;
 using SFA.DAS.Reservations.Application.Rules.Queries;
 using SFA.DAS.Reservations.Application.Rules.Services;
@@ -27,6 +27,7 @@ using SFA.DAS.Reservations.Domain.Reservations;
 using SFA.DAS.Reservations.Domain.Rules;
 using SFA.DAS.Reservations.Domain.Validation;
 using SFA.DAS.Reservations.Infrastructure.Configuration;
+
 
 namespace SFA.DAS.Reservations.Api
 {
@@ -64,6 +65,10 @@ namespace SFA.DAS.Reservations.Api
 
             var serviceProvider = services.BuildServiceProvider();
             var config = serviceProvider.GetService<IOptions<ReservationsConfiguration>>();
+            
+
+            services.AddHealthChecks()
+                    .AddSqlServer(config.Value.ConnectionString);
 
             if (!ConfigurationIsLocalOrDev())
             {
@@ -145,6 +150,8 @@ namespace SFA.DAS.Reservations.Api
             }
 
             app.UseHttpsRedirection();
+            
+            app.UseHealthChecks();
             
             app.UseMvc(routes =>
             {

--- a/src/SFA.DAS.Reservations.Api/StartupConfig/HealthCheckStartup.cs
+++ b/src/SFA.DAS.Reservations.Api/StartupConfig/HealthCheckStartup.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using SFA.DAS.Reservations.Infrastructure.HealthCheck;
+
+namespace SFA.DAS.Reservations.Api.StartupConfig
+{
+    public static class HealthCheckStartup
+    {
+        public static IApplicationBuilder UseHealthChecks(this IApplicationBuilder app)
+        {
+            app.UseHealthChecks("/health", new HealthCheckOptions
+            {
+                ResponseWriter = HealthCheckResponseWriter.WriteJsonResponse
+            });
+            
+            app.UseHealthChecks("/ping", new HealthCheckOptions
+            {
+                Predicate = (_) => false
+            });
+
+            return app;
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Infrastructure/HealthCheck/HealthCheckResponseWriter.cs
+++ b/src/SFA.DAS.Reservations.Infrastructure/HealthCheck/HealthCheckResponseWriter.cs
@@ -1,0 +1,28 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SFA.DAS.Reservations.Infrastructure.HealthCheck
+{
+    public static class HealthCheckResponseWriter
+    {
+        public static Task WriteJsonResponse(HttpContext httpContext, HealthReport result)
+        {
+            httpContext.Response.ContentType = "application/json";
+
+            var json = new JObject(
+                new JProperty("status", result.Status.ToString()),
+                new JProperty("results", new JObject(result.Entries.Select(pair =>
+                    new JProperty(pair.Key, new JObject(
+                        new JProperty("status", pair.Value.Status.ToString()),
+                        new JProperty("description", pair.Value.Description),
+                        new JProperty("data", new JObject(pair.Value.Data.Select(
+                            p => new JProperty(p.Key, p.Value))))))))));
+            return httpContext.Response.WriteAsync(
+                json.ToString(Formatting.Indented));
+        }
+    }
+}

--- a/src/SFA.DAS.Reservations.Infrastructure/SFA.DAS.Reservations.Infrastructure.csproj
+++ b/src/SFA.DAS.Reservations.Infrastructure/SFA.DAS.Reservations.Infrastructure.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Same as with the web health checks.  '/ping' returns if API is up and running. '/health' returns if the service is actually running correctly.