### PR TITLE
Added 2 QnA API Nuget package build steps into Asssesor

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,24 @@ jobs:
       versioningScheme: byBuildNumber
       buildProperties: 'Version="$(Build.BuildNumber)"'
 
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet pack'
+    inputs:
+      command: pack
+      packagesToPack: src/SFA.DAS.Qna.Api.Types/SFA.DAS.Qna.Api.Types.csproj
+      packDirectory: '$(build.artifactstagingdirectory)/publish'
+      versioningScheme: byBuildNumber
+      buildProperties: 'Version="$(Build.BuildNumber)"'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'dotnet pack'
+    inputs:
+      command: pack
+      packagesToPack: src/SFA.DAS.QnA.Api.Client/SFA.DAS.QnA.Api.Client.csproj
+      packDirectory: '$(build.artifactstagingdirectory)/publish'
+      versioningScheme: byBuildNumber
+      buildProperties: 'Version="$(Build.BuildNumber)"'
+
   - task: CopyFiles@2
     displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
     inputs:


### PR DESCRIPTION
Amend the QnA-API YML file to include 2x dotnet pack tasks similar to reservations API to pack two new Nuget packages as part of the build process.