### PR TITLE
MF-34 reservation delete notification

### DIFF
--- a/src/SFA.DAS.Reservations.Api.AcceptanceTests/Steps/DeleteReservationSteps.cs
+++ b/src/SFA.DAS.Reservations.Api.AcceptanceTests/Steps/DeleteReservationSteps.cs
@@ -21,7 +21,7 @@ namespace SFA.DAS.Reservations.Api.AcceptanceTests.Steps
         {
             var controller = Services.GetService<ReservationsController>();
 
-            controller.Delete(TestData.ReservationId).Wait(5000);
+            controller.Delete(TestData.ReservationId, true).Wait(5000);
         }
         
         [Then(@"the reservation should be deleted")]

--- a/src/SFA.DAS.Reservations.Api.UnitTests/Controllers/Reservation/WhenDeletingAReservation.cs
+++ b/src/SFA.DAS.Reservations.Api.UnitTests/Controllers/Reservation/WhenDeletingAReservation.cs
@@ -21,17 +21,18 @@ namespace SFA.DAS.Reservations.Api.UnitTests.Controllers.Reservation
         [Test, MoqAutoData]
         public async Task And_ArgumentException_Then_Returns_BadRequest(
             Guid reservationId,
+            bool employerDeleted,
             ArgumentException argumentException,
             [Frozen] Mock<IMediator> mockMediator,
             ReservationsController controller)
         {
             mockMediator
                 .Setup(mediator => mediator.Send(
-                    It.IsAny<DeleteReservationCommand>(), 
+                    It.IsAny<DeleteReservationCommand>(),
                     It.IsAny<CancellationToken>()))
                 .ThrowsAsync(argumentException);
 
-            var result = await controller.Delete(reservationId) as BadRequestObjectResult;
+            var result = await controller.Delete(reservationId, employerDeleted) as BadRequestObjectResult;
 
             result.Should().NotBeNull();
             result.StatusCode.Should().Be(400);
@@ -44,17 +45,18 @@ namespace SFA.DAS.Reservations.Api.UnitTests.Controllers.Reservation
         [Test, MoqAutoData]
         public async Task And_EntityNotFoundException_Then_Returns_Gone(
             Guid reservationId,
+            bool employerDeleted,
             EntityNotFoundException<Domain.Entities.Reservation> notFoundException,
             [Frozen] Mock<IMediator> mockMediator,
             ReservationsController controller)
         {
             mockMediator
                 .Setup(mediator => mediator.Send(
-                    It.IsAny<DeleteReservationCommand>(), 
+                    It.IsAny<DeleteReservationCommand>(),
                     It.IsAny<CancellationToken>()))
                 .ThrowsAsync(notFoundException);
 
-            var result = await controller.Delete(reservationId) as StatusCodeResult;
+            var result = await controller.Delete(reservationId, employerDeleted) as StatusCodeResult;
 
             result.Should().NotBeNull();
             result.StatusCode.Should().Be(410);
@@ -63,17 +65,18 @@ namespace SFA.DAS.Reservations.Api.UnitTests.Controllers.Reservation
         [Test, MoqAutoData]
         public async Task And_InvalidOperationException_Then_Returns_BadRequest(
             Guid reservationId,
+            bool employerDeleted,
             InvalidOperationException invalidOperationException,
             [Frozen] Mock<IMediator> mockMediator,
             ReservationsController controller)
         {
             mockMediator
                 .Setup(mediator => mediator.Send(
-                    It.IsAny<DeleteReservationCommand>(), 
+                    It.IsAny<DeleteReservationCommand>(),
                     It.IsAny<CancellationToken>()))
                 .ThrowsAsync(invalidOperationException);
 
-            var result = await controller.Delete(reservationId) as BadRequestResult;
+            var result = await controller.Delete(reservationId, employerDeleted) as BadRequestResult;
 
             result.Should().NotBeNull();
             result.StatusCode.Should().Be(400);
@@ -82,11 +85,18 @@ namespace SFA.DAS.Reservations.Api.UnitTests.Controllers.Reservation
         [Test, MoqAutoData]
         public async Task And_No_Error_Then_Returns_Ok(
             Guid reservationId,
+            bool employerDeleted,
             [Frozen] Mock<IMediator> mockMediator,
             ReservationsController controller)
         {
-            var result = await controller.Delete(reservationId) as NoContentResult;
+            var result = await controller.Delete(reservationId, employerDeleted) as NoContentResult;
 
+            mockMediator.Verify(x =>
+                x.Send(
+                    It.Is<DeleteReservationCommand>(c =>
+                        c.ReservationId.Equals(reservationId)
+                        && c.EmployerDeleted.Equals(employerDeleted)),
+                    It.IsAny<CancellationToken>()), Times.Once);
             result.Should().NotBeNull();
             result.StatusCode.Should().Be(204);
         }

--- a/src/SFA.DAS.Reservations.Api/Controllers/ReservationsController.cs
+++ b/src/SFA.DAS.Reservations.Api/Controllers/ReservationsController.cs
@@ -187,11 +187,11 @@ namespace SFA.DAS.Reservations.Api.Controllers
         [ProducesResponseType(400)]
         [ProducesResponseType(410)]
         [Route("api/[controller]/{id}")]
-        public async Task<IActionResult> Delete(Guid id)
+        public async Task<IActionResult> Delete(Guid id, bool employerDeleted)
         {
             try
             {
-                await _mediator.Send(new DeleteReservationCommand {ReservationId = id});
+                await _mediator.Send(new DeleteReservationCommand {ReservationId = id, EmployerDeleted = employerDeleted});
                 return NoContent();
             }
             catch (ArgumentException argumentException)

--- a/src/SFA.DAS.Reservations.Application.UnitTests/AccountReservation/Commands/DeleteReservation/WhenDeletingAReservation.cs
+++ b/src/SFA.DAS.Reservations.Application.UnitTests/AccountReservation/Commands/DeleteReservation/WhenDeletingAReservation.cs
@@ -77,6 +77,7 @@ namespace SFA.DAS.Reservations.Application.UnitTests.AccountReservation.Commands
                 && e.StartDate.Equals(reservationToDelete.StartDate)
                 && e.EndDate.Equals(reservationToDelete.ExpiryDate)
                 && e.CreatedDate.Equals(reservationToDelete.CreatedDate)
+                && e.EmployerDeleted.Equals(command.EmployerDeleted)
                 )), Times.Once);
         }
     }

--- a/src/SFA.DAS.Reservations.Application/AccountReservations/Commands/DeleteReservation/DeleteReservationCommand.cs
+++ b/src/SFA.DAS.Reservations.Application/AccountReservations/Commands/DeleteReservation/DeleteReservationCommand.cs
@@ -6,5 +6,6 @@ namespace SFA.DAS.Reservations.Application.AccountReservations.Commands.DeleteRe
     public class DeleteReservationCommand : IRequest<Unit>
     {
         public Guid ReservationId { get; set; }
+        public bool EmployerDeleted { get; set; }
     }
 }

--- a/src/SFA.DAS.Reservations.Application/AccountReservations/Commands/DeleteReservation/DeleteReservationCommandHandler.cs
+++ b/src/SFA.DAS.Reservations.Application/AccountReservations/Commands/DeleteReservation/DeleteReservationCommandHandler.cs
@@ -49,7 +49,8 @@ namespace SFA.DAS.Reservations.Application.AccountReservations.Commands.DeleteRe
                 reservationToDelete.Course?.CourseId,
                 reservationToDelete.Course?.Title,
                 reservationToDelete.Course?.Level,
-                reservationToDelete.ProviderId);
+                reservationToDelete.ProviderId,
+                command.EmployerDeleted);
 
             await _reservationService.DeleteReservation(command.ReservationId);
             

--- a/src/SFA.DAS.Reservations.Messages/ReservationDeletedEvent.cs
+++ b/src/SFA.DAS.Reservations.Messages/ReservationDeletedEvent.cs
@@ -8,7 +8,7 @@ namespace SFA.DAS.Reservations.Messages
             long accountId, long accountLegalEntityId, string accountLegalEntityName,
             DateTime startDate, DateTime endDate, DateTime createdDate, 
             string courseId, string courseName, string courseLevel,
-            uint? providerId)
+            uint? providerId, bool employerDeleted)
         {
             Id = id;
             AccountId = accountId;
@@ -21,6 +21,7 @@ namespace SFA.DAS.Reservations.Messages
             CourseName = courseName;
             CourseLevel = courseLevel;
             ProviderId = providerId;
+            EmployerDeleted = employerDeleted;
         }
 
         public Guid Id { get; set; }
@@ -34,5 +35,6 @@ namespace SFA.DAS.Reservations.Messages
         public string CourseName { get; set; }
         public string CourseLevel { get; set; }
         public uint? ProviderId { get; set; }
+        public bool EmployerDeleted { get; set; }
     }
 }


### PR DESCRIPTION
Update reservation deleted event
Updated the delete action to accept a parameter to determine whether or not the delete has been triggered by the employer or the provider.