### PR TITLE
CV-754 - Only update to levy for change reservation

### DIFF
--- a/src/SFA.DAS.Reservations.Api.AcceptanceTests/Features/ChangeOfParty.feature
+++ b/src/SFA.DAS.Reservations.Api.AcceptanceTests/Features/ChangeOfParty.feature
@@ -49,7 +49,7 @@ Scenario: Change employer, levy to non-levy
 	And I have the following reservations:
 	| Account Legal Entity Id | Provider Id | Start Date | Created Date | Course Id | Status    | Is Levy Account |
 	| 10                      | 15214       | 2019-07-01 | 2019-01-01   | 1         | Confirmed | True            |
-	| 2                       | 15214       | 2019-07-01 | today        | 1         | Change    | False           |
+	| 2                       | 15214       | 2019-07-01 | today        | 1         | Change    | True           |
 	
 Scenario: Change provider
 	Given I have the following existing reservation:

--- a/src/SFA.DAS.Reservations.Application/AccountReservations/Services/AccountReservationService.cs
+++ b/src/SFA.DAS.Reservations.Application/AccountReservations/Services/AccountReservationService.cs
@@ -151,7 +151,7 @@ namespace SFA.DAS.Reservations.Application.AccountReservations.Services
                 newReservation.AccountId = newAccountLegalEntity.AccountId;
                 newReservation.AccountLegalEntityId = newAccountLegalEntity.AccountLegalEntityId;
                 newReservation.AccountLegalEntityName = newAccountLegalEntity.AccountLegalEntityName;
-                newReservation.IsLevyAccount = newAccountLegalEntity.Account.IsLevy;
+                newReservation.IsLevyAccount = newAccountLegalEntity.Account.IsLevy ? newAccountLegalEntity.Account.IsLevy : existingReservation.IsLevyAccount;
             } 
             else if (request.ProviderId.HasValue)
             {


### PR DESCRIPTION
Reservations that are being cloned, will only have their levy status changed to levy, it can not go back from this once changed. This is to fix an issue where an apprentice started a framework and now is transferred to a non levy employer.